### PR TITLE
Cross build for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,28 +4,43 @@ version := "3.0.2"
 
 organization := "com.twitter"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.6"
 
-crossScalaVersions := Seq("2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
 
 scalacOptions += "-language:implicitConversions"
 
-javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
+javacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+      Seq("-source", "1.8", "-target", "1.8")
+    case _ =>
+      Seq("-source", "1.6", "-target", "1.6")
+  }
+}
 
-javacOptions in doc := Seq("-source", "1.6")
+javacOptions in doc := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+      Seq("-source", "1.8")
+    case _ =>
+      Seq("-source", "1.6")
+  }
+}
 
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.2" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test",
   "junit" % "junit" % "4.10" % "test"
 )
 
-libraryDependencies <++= scalaVersion { (v: String) =>
-  CrossVersion.partialVersion(v) match {
+libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2")
-    case _ => Seq()
+    case _ =>
+      Seq.empty
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,29 +4,15 @@ version := "3.0.2"
 
 organization := "com.twitter"
 
-scalaVersion := "2.10.6"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-M4")
+crossScalaVersions := Seq("2.11.8", "2.12.0-M4")
 
 scalacOptions += "-language:implicitConversions"
 
-javacOptions ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
-      Seq("-source", "1.8", "-target", "1.8")
-    case _ =>
-      Seq("-source", "1.6", "-target", "1.6")
-  }
-}
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-javacOptions in doc := {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
-      Seq("-source", "1.8")
-    case _ =>
-      Seq("-source", "1.6")
-  }
-}
+javacOptions in doc := Seq("-source", "1.8")
 
 parallelExecution in Test := false
 
@@ -38,7 +24,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-      Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2")
+      Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4")
     case _ =>
       Seq.empty
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.11


### PR DESCRIPTION
Problem

There exists a need to publish artifacts that are
binary compatible with Scala 2.12.

Solution

Modify sbt build defintion to cross build for 2.12.
